### PR TITLE
Refactoring and fixing Nil pointer dereference error

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Vulnerabilites Covered:
 * TE.CL vulnerabilities
 * TE.TE vulnerabilities
 
+![go-smuggler](https://github.com/poseidontor/go-smuggler/assets/24155514/24da3097-590f-468c-a774-6d8c2ffd922c)
+
+
 ### Security Consent
 It's quite important to know some of the legal disclaimers before scanning any of the targets, you should have proper authorization before scanning any of the targets otherwise I suggest do not use this tool to scan an unauthorized target because to detect the vulnerability it sends multiple payloads for multiple times which means if something goes wrong then there is a possibility that backend socket might get poisoned with the payloads and any genuine visitors of that particular website might end up seeing the poisoned payload rather seeing the actual content of the website. So I'll highly suggest taking proper precautions before scanning any of the target website otherwise you will face some legal issue.
 

--- a/internal/requests/requests.go
+++ b/internal/requests/requests.go
@@ -4,41 +4,40 @@ import (
 	"fmt"
 	"log"
 	"github.com/tomnomnom/rawhttp"
+	"github.com/poseidontor/go-smuggler/internal/structures"
 	"time"
 )
 
-func Make_request_http1(hostname string, port string, path string, content_type string, 
-	connection string, transfer_encoding string, content_length string, body string, timeout time.Duration ) (resp *rawhttp.Response) {
+func MakeRequestHttp(httpRequest structures.HttpRequest) (resp *rawhttp.Response) {
 	
-	req, err_http := rawhttp.FromURL("POST", "https://"+hostname+"/")
+	req, err_http := rawhttp.FromURL("POST", "https://"+httpRequest.Hostname+"/")
 	if err_http != nil {
 		log.Fatal(err_http)
 	}
 		
 	req.Method = "POST"
 	req.Proto = "HTTP/1.1"
-	req.Hostname = hostname
-	req.Port = port
-	req.Path = path
+	req.Hostname = httpRequest.Hostname
+	req.Port = httpRequest.Port
+	req.Path = httpRequest.Path
 
 	//automatically assign host header value
 	req.AutoSetHost()
 
 	//setting headers
-	req.AddHeader(content_type)
-	req.AddHeader(connection)
-	req.AddHeader(transfer_encoding)
+	req.AddHeader(httpRequest.ContentType)
+	req.AddHeader(httpRequest.Connection)
+	req.AddHeader(httpRequest.TransferEncoding)
 
-	req.Body = body
-	req.Timeout = timeout * time.Second
+	req.Body = httpRequest.Body
+	req.Timeout = httpRequest.Timeout * time.Second
 	
 	//Automatically set content-length if not specified
-	if content_length == ""	{
+	if httpRequest.ContentLength == ""	{
 		req.AutoSetContentLength()
 	}	else {
-		req.AddHeader(content_length)
+		req.AddHeader(httpRequest.ContentLength)
 	}
-	//fmt.Printf("%s\n\n", req.String())
 	
 	resp, err_req := rawhttp.Do(req)
 	if err_req != nil {

--- a/internal/requests/requests.go
+++ b/internal/requests/requests.go
@@ -1,14 +1,14 @@
 package requests
 
 import (
-	"fmt"
+	//"fmt"
 	"log"
 	"github.com/tomnomnom/rawhttp"
 	"github.com/poseidontor/go-smuggler/internal/structures"
 	"time"
 )
 
-func MakeRequestHttp(httpRequest structures.HttpRequest) (resp *rawhttp.Response) {
+func MakeRequestHttp(httpRequest structures.HttpRequest) (resp *rawhttp.Response, err_req error) {
 	
 	req, err_http := rawhttp.FromURL("POST", "https://"+httpRequest.Hostname+"/")
 	if err_http != nil {
@@ -39,9 +39,9 @@ func MakeRequestHttp(httpRequest structures.HttpRequest) (resp *rawhttp.Response
 		req.AddHeader(httpRequest.ContentLength)
 	}
 	
-	resp, err_req := rawhttp.Do(req)
-	if err_req != nil {
-		fmt.Printf("[-] Connection Error: %s\n", err_req)
-	}
-	return
+	resp, err_req = rawhttp.Do(req)
+
+	return resp, err_req
+
+
 }

--- a/internal/structures/httpRequest.go
+++ b/internal/structures/httpRequest.go
@@ -1,0 +1,19 @@
+package structures
+
+import (
+	"time"
+)
+
+type HttpRequest struct	{
+	
+	Hostname string
+	Port string
+	Path string
+	ContentType string
+	Connection string
+	TransferEncoding string
+	ContentLength string
+	Body string
+	Timeout time.Duration
+	
+}

--- a/internal/test_cases/clte.go
+++ b/internal/test_cases/clte.go
@@ -34,8 +34,12 @@ func Clte(hostname string, port string, path string, time_out time.Duration)	{
 		transfer_encoding := payload.Cases[i].TransferEncoding
 		body := payload.Cases[i].Body
 
-		resp[i] = requests.Make_request_http1(hostname, port, path, 
-		content_type, connection, transfer_encoding, "", body, timeout);
+		httpRequest := structures.HttpRequest{Hostname: hostname, Port: port, Path: path, 
+			ContentType: content_type, Connection: connection, 
+			TransferEncoding: transfer_encoding, ContentLength: "", 
+			Body: body, 
+			Timeout: timeout}
+		resp[i] = requests.MakeRequestHttp(httpRequest);
 	}
 	
 	if resp[0].StatusCode() == "504" || resp[1].StatusCode() == "504" {

--- a/internal/test_cases/clte.go
+++ b/internal/test_cases/clte.go
@@ -28,6 +28,7 @@ func Clte(hostname string, port string, path string, time_out time.Duration)	{
 	var timeout time.Duration = time_out
 
 	var resp[2]*rawhttp.Response
+	var err[2]error
 	for i := 0; i < 2; i++	{
 		content_type := payload.Cases[i].ContentType
 		connection := payload.Cases[i].Connnection
@@ -39,18 +40,23 @@ func Clte(hostname string, port string, path string, time_out time.Duration)	{
 			TransferEncoding: transfer_encoding, ContentLength: "", 
 			Body: body, 
 			Timeout: timeout}
-		resp[i] = requests.MakeRequestHttp(httpRequest);
+		resp[i],err[i] = requests.MakeRequestHttp(httpRequest);
 	}
 	
-	if resp[0].StatusCode() == "504" || resp[1].StatusCode() == "504" {
-		fmt.Printf("[-] Received 504: Gateway Timeout for %s\n", hostname)
-	}
+	if(err[0] == nil && err[1] == nil) {
+		if resp[0].StatusCode() == "504" || resp[1].StatusCode() == "504" {
+			fmt.Printf("[-] Received 504: Gateway Timeout for %s\n", hostname)
+		}
 
-	if resp[0].StatusCode() == "500" && resp[1].StatusCode() == "200" {
-		color.Red("[+] https://%s:%s%s could possibly be vulnerble to CL.TE based request smuggling.\n", hostname, 
-	port, path)
-	}
-	secs := time.Since(start).Seconds()
+		if resp[0].StatusCode() == "500" && resp[1].StatusCode() == "200" {
+			color.Red("[+] https://%s:%s%s could possibly be vulnerble to CL.TE based request smuggling.\n", hostname, 
+			port, path)
+		}
+		secs := time.Since(start).Seconds()
 
-	fmt.Printf("%.2f seconds taken for https://%s:%s%s\n", secs, hostname, port, path)
+		fmt.Printf("%.2f seconds taken for https://%s:%s%s\n", secs, hostname, port, path)
+
+	} else {
+		fmt.Printf("Request for %s errored out!\n" , hostname)
+	}
 }

--- a/internal/test_cases/tecl.go
+++ b/internal/test_cases/tecl.go
@@ -28,6 +28,7 @@ func Tecl(hostname string, port string, path string, time_out time.Duration)	{
 	var timeout time.Duration = time_out
 
 	var resp[2]*rawhttp.Response
+	var err[2]error 
 	for i := 0; i < 2; i++	{
 		content_type := payload.Cases[i].ContentType
 		connection := payload.Cases[i].Connnection
@@ -41,18 +42,22 @@ func Tecl(hostname string, port string, path string, time_out time.Duration)	{
 			ContentLength: content_length, Body: body, 
 			Timeout: timeout}
 
-		resp[i] = requests.MakeRequestHttp(httpRequest);
+		resp[i], err[i] = requests.MakeRequestHttp(httpRequest);
 	}
-	if resp[0] != nil && resp[1] != nil{ 
-		if resp[0].StatusCode() == "504" || resp[1].StatusCode() == "504" {
-			fmt.Printf("[-] Received 504: Gateway Timeout for %s\n", hostname)
-		}
+	if(err[0] == nil && err[1] == nil){
+		if resp[0] != nil && resp[1] != nil{ 
+			if resp[0].StatusCode() == "504" || resp[1].StatusCode() == "504" {
+				fmt.Printf("[-] Received 504: Gateway Timeout for %s\n", hostname)
+			}
 
-		if resp[0].StatusCode() == "500" && resp[1].StatusCode() == "200" {
-			color.Red("[+] https://%s:%s%s could possibly be vulnerble to TE.CL based request smuggling.\n", hostname, port, path)
-		}
-		secs := time.Since(start).Seconds()
+			if resp[0].StatusCode() == "500" && resp[1].StatusCode() == "200" {
+				color.Red("[+] https://%s:%s%s could possibly be vulnerble to TE.CL based request smuggling.\n", hostname, port, path)
+			}
+			secs := time.Since(start).Seconds()
 
-		fmt.Printf("%.2f seconds taken for https://%s:%s%s\n", secs, hostname, port, path)
+			fmt.Printf("%.2f seconds taken for https://%s:%s%s\n", secs, hostname, port, path)
+		}
+	} else {
+		fmt.Printf("Request for %s errored out!\n" , hostname)
 	}
 }

--- a/internal/test_cases/tecl.go
+++ b/internal/test_cases/tecl.go
@@ -35,8 +35,13 @@ func Tecl(hostname string, port string, path string, time_out time.Duration)	{
 		body := payload.Cases[i].Body
 		content_length := payload.Cases[i].ContentLength
 
-		resp[i] = requests.Make_request_http1(hostname, port, path, 
-		content_type, connection, transfer_encoding, content_length, body, timeout);
+		httpRequest := structures.HttpRequest{Hostname: hostname, Port: port, 
+			Path: path, ContentType: content_type, 
+			Connection: connection, TransferEncoding: transfer_encoding, 
+			ContentLength: content_length, Body: body, 
+			Timeout: timeout}
+
+		resp[i] = requests.MakeRequestHttp(httpRequest);
 	}
 	if resp[0] != nil && resp[1] != nil{ 
 		if resp[0].StatusCode() == "504" || resp[1].StatusCode() == "504" {

--- a/internal/test_cases/tete.go
+++ b/internal/test_cases/tete.go
@@ -39,7 +39,12 @@ func Tete(hostname string, port string, path string, time_out time.Duration)	{
 			body := value.Body
 			content_length := value.ContentLength
 
-			resp[i] = requests.Make_request_http1(hostname, port, path, content_type, connection, transfer_encoding, content_length, body, timeout);
+			httpRequest := structures.HttpRequest{Hostname: hostname, Port: port, 
+				Path: path, ContentType: content_type, 
+				Connection: connection, TransferEncoding: transfer_encoding, 
+				ContentLength: content_length, Body: body, 
+				Timeout: timeout}
+			resp[i] = requests.MakeRequestHttp(httpRequest);
 			time.Sleep(10 * time.Millisecond)
 		}
 		


### PR DESCRIPTION
Refactored:
* The Requests.MakeRequestHttp method to take a HttpRequest struct as parameter.
* Modified the test case classes consuming the MakeRequestHttp method to reflect the above change.

Error fix:
MakeRequestHttp was using naked return and only returning the response. Changed it to named return and now the method is returning both the response as well as the error (doing it the golang way now!!). Updated the code consuming this function to handle the error case. 
